### PR TITLE
Remove hardcoded values from slurmHost.py and ensure that walltime from config is used

### DIFF
--- a/appion/appionlib/slurmHost.py
+++ b/appion/appionlib/slurmHost.py
@@ -36,25 +36,16 @@ class SlurmHost(processingHost.ProcessingHost):
                
              
 		#Every Shell Script starts by indicating shell type
-		header = "#!/usr/bin/sh\n"
-		#header = "#!" + self.getShell() + "\n"
-                #header += "source /usr/share/Modules/init/tcsh;\n"
-                #header += "source /panfs/storage.local/imb/stagg/software/etc/myamidev.csh;\n"
+		header = "#!" + self.getShell() + "\n"
 			   
 		#add job attribute headers
 		if currentJob.getWalltime():
-			# header += self.scriptPrefix +" -t " + str(currentJob.getWalltime())+":00:00\n"
-                        header += self.scriptPrefix +" -t 2:00:00\n"
+			header += self.scriptPrefix +" -t " + str(currentJob.getWalltime())+":00:00\n"
                         
 		if currentJob.getNodes():
 			header += self.scriptPrefix +" -N " + str(currentJob.getNodes())
-			#if currentJob.getPPN():
-			#	header += ":ppn=" + str(currentJob.getPPN())
 			header += "\n"
 		
-		#if currentJob.getCpuTime():
-			# header += self.scriptPrefix +" -l cput=" + str(currentJob.getCpuTime()) + ":00:00\n"
-			
 		if currentJob.getMem():
 			header += self.scriptPrefix +" --mem=" + str(currentJob.getMem()) + 'gb\n'
 		
@@ -64,8 +55,8 @@ class SlurmHost(processingHost.ProcessingHost):
 		if currentJob.getQueue():
 			header += self.scriptPrefix +" -p " + currentJob.getQueue() + "\n"
 			
-		#if currentJob.getAccount():
-		#	header += self.scriptPrefix +" -A " + currentJob.getAccount()+ "\n"
+		if currentJob.getAccount():
+			header += self.scriptPrefix +" -A " + currentJob.getAccount()+ "\n"
 			
 		#Add any custom headers for this processing host.
 		for line in self.getAdditionalHeaders():

--- a/myamiweb/processing/inc/processing.inc
+++ b/myamiweb/processing/inc/processing.inc
@@ -558,6 +558,14 @@ function getMaxNumberOfProcsPerNode( $processingHost )
 	return $ppn;
 }
 
+function getWalltime( $processingHost ) 
+{
+	$cluster = new Cluster( $processingHost );
+	$walltime = $cluster->getWallTimeDef();
+	
+	return $walltime;
+}
+
 function getNumberOfRequiredNodes($nproc, $ppn) 
 {
 	if ($nproc < $ppn) {
@@ -712,7 +720,8 @@ function showOrSubmitCommand($command, $headinfo, $jobtype, $nproc, $testimg=Fal
 			return "<B>ERROR:</B> Enter a user name and password";
 		}
 
-		$errors = submitAppionJob($command, $outdir, $runname, $expId, $jobtype, $testimg, False, False, $nproc, $ppn, $nodes);
+		$walltime = getWalltime($processhost);
+		$errors = submitAppionJob($command, $outdir, $runname, $expId, $jobtype, $testimg, False, False, $nproc, $ppn, $nodes, $walltime);
 		
 		// if errors:
 		if ($errors) {


### PR DESCRIPTION
This fixes [16172](https://emg.nysbc.org/redmine/issues/16172).