### PR TITLE
refs #13 fixes to handle RGB images

### DIFF
--- a/pyami/numpil.py
+++ b/pyami/numpil.py
@@ -80,10 +80,9 @@ def readInfo(imfile):
 	extrema = im.getextrema()
 	number_of_bands = len(im.getbands())
 	if number_of_bands > 1:
-		print(number_of_bands)
 		# multibands, use the most extreme value. Don't know what to do.
-		info['amin'] = min(list(map((lambda x:x[0],extrema))))
-		info['amax'] = min(list(map((lambda x:x[1],extrema))))
+		info['amin'] = min(list(map((lambda x:x[0]),extrema)))
+		info['amax'] = min(list(map((lambda x:x[1]),extrema)))
 	else:
 		info['amin'] = extrema[0]
 		info['amax'] = extrema[1]

--- a/redux/pipes/format.py
+++ b/redux/pipes/format.py
@@ -4,6 +4,7 @@ import io
 # 3rd party
 import scipy.misc
 from PIL import Image
+import numpy
 
 # myami
 import pyami.mrc
@@ -63,6 +64,8 @@ class Format(redux.pipe.Pipe):
 
 	def run_pil(self, input, oformat, rgb, overlay, overlaycolor):
 		# pil_image = scipy.misc.toimage(input, cmin=0, cmax=255)
+		# refs Issue #13 input is float if going through intensity scaling.
+		input = input.astype(numpy.uint8)
 		pil_image = Image.fromarray(input)
 		if rgb or overlay:
 			pil_image = pil_image.convert('RGBA')


### PR DESCRIPTION
This PR includes conversion to uint8 and also a bug found in pyami/numpil.py during python3 conversion.