### PR TITLE
two WebUI nysbc features after plenty of testing

### DIFF
--- a/myamiweb/index.php
+++ b/myamiweb/index.php
@@ -9,6 +9,13 @@
 
 require_once "inc/leginon.inc";
 
+function show_session_finder() {
+    if (defined("SHOW_SESSION_FINDER")) {
+        return SHOW_SESSION_FINDER;
+    }
+    return true;
+}
+
 $baseurl = BASE_URL;
 
 $link = new iconlink();
@@ -65,13 +72,16 @@ login_header(PROJECT_TITLE,'','',true);
 <p>
 		<?php echo $link->Display(); ?>
 </p>
-		<?php #if (HIDE_FEATURE === false) { ?>
-<label for="query"><strong>Session finder:</strong>&nbsp;
-<input style="border: 1px solid #bdcebb;" type="text" name="search" autocomplete="off" id="query" onKeyUp="preSearch()" />
-</label>
-<p>
-<div style="border: 1px solid #bdcebb; padding-left: 5px" id="result">&nbsp;</div>
 </p>
-<?php #}
+
+<?php if (show_session_finder()) { ?>
+    <label for="query"><strong>Session finder:</strong>&nbsp;
+    <input style="border: 1px solid #bdcebb;" type="text" name="search" autocomplete="off" id="query" onKeyUp="preSearch()" />
+    </label>
+    <p>
+    <div style="border: 1px solid #bdcebb; padding-left: 5px" id="result">&nbsp;</div>
+    </p>
+<?php }
+
 login_footer();
 ?>

--- a/myamiweb/processing/inc/cluster.inc
+++ b/myamiweb/processing/inc/cluster.inc
@@ -349,8 +349,8 @@ class Cluster {
         if (!$returnResult)
             return true;
 
-        // Setting blocking to true can cause it to hang.
-        stream_set_blocking($stream, false);
+        // block to wait for process to exit
+        stream_set_blocking($stream, true);
 
         //error_log("Command = ".$command." max_time =".$max_time);
         // This block will wait a given time to get a result from the output stream.


### PR DESCRIPTION
7648ff:  This changes the cluster/slurm API to wait for the call to the external process to finish.  Not doing so can lead to non-sensical returns before the process is done with its work.

bfc393: On NCCAT we chose to clarify hiding the session finder with a new function, instead of the very generic "HIDE_FEATURE". 